### PR TITLE
Fixed the share-this-step workflow ;)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -35,10 +35,10 @@ workflows:
   share-this-step:
     envs:
       # if you want to share this step into a StepLib
-      - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/emenegro/bitrise-step-product-bundle-identifier
-      - STEP_ID_IN_STEPLIB: set-ios-product-bundle-identifier.git
-      - STEP_GIT_VERION_TAG_TO_SHARE: 1.0.1
-      - STEP_GIT_CLONE_URL: https://github.com/emenegro/bitrise-step-product-bundle-identifier
+      - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/emenegro/bitrise-steplib.git
+      - STEP_ID_IN_STEPLIB: set-ios-product-bundle-identifier
+      - STEP_GIT_VERION_TAG_TO_SHARE: 1.1.3
+      - STEP_GIT_CLONE_URL: https://github.com/emenegro/bitrise-step-product-bundle-identifier.git
     description: |-
       If this is the first time you try to share a Step you should
       first call: $ bitrise share


### PR DESCRIPTION
So that you can share the step with:

```
bitrise run share-this-step
```